### PR TITLE
Set up pgadmin for docker #93

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY /forum/requirements.txt .
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY entrypoint.sh /app/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,18 @@ services:
     env_file:
       - .env
 
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    ports:
+      - "5050:80"
+    depends_on:
+      - db
+    env_file:
+      - .env
+
   db:
     image: postgres:15
     environment:
@@ -28,3 +40,4 @@ services:
 
 volumes:
   postgres_data:
+  pgadmin_data:


### PR DESCRIPTION
- set up pgadmin for Docker (and successfully connected to PostgreSQL using my local credentials for login-password)
- edited entrypoint.sh format from CRLF to LF so docker-compose properly runs all commands in shell
- added .gitattributes with instruction to git to **not convert** .sh files' format from LF to CRLF (as it used to earlier)
![image](https://github.com/user-attachments/assets/2b9d6201-c80c-4308-a25d-ac5c5e24513f)
all services run successfully and properly