### PR TITLE
Set up JWT authentication

### DIFF
--- a/forum/forum/settings.py
+++ b/forum/forum/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     'rest_framework',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     'users',
     'profiles',
     'projects',
@@ -141,9 +142,11 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
-    'ROTATE_REFRESH_TOKENS': False,
-    'BLACKLIST_AFTER_ROTATION': False,
-    'SIGNINS_KEY': SECRET_KEY,
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
+    'ALGORITHM': 'HS256',
+    'AUTH_HEADER_TYPES': ('Bearer'),
+    'SIGNING_KEY': SECRET_KEY,
     'USER_ID_FIELD': 'user_id',
     'USER_ID_CLAIM': 'user_id',
 }   

--- a/forum/forum/urls.py
+++ b/forum/forum/urls.py
@@ -22,6 +22,4 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path('api/users/', include('users.urls')),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/forum/users/urls.py
+++ b/forum/users/urls.py
@@ -6,5 +6,5 @@ from .views import RegisterView
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('refresh/', TokenRefreshView.as_view(), name='toekn_refresh'),    
+    path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),    
 ]


### PR DESCRIPTION
- set up JWT authentication via DRF's DEFAULT_AUTHENTICATION_CLASSES
- added SIMPLE_JWT section in settings.py with basic configuration 
- tested creating and refreshing tokens with added endpoints (using Postman)
![image](https://github.com/user-attachments/assets/8e2ad6e7-9c95-4228-98eb-eeb23a040d19)
![image](https://github.com/user-attachments/assets/fde180c9-4c92-42a7-a99a-6442bf27f4c3)
