### PR TITLE
Implement user sign up #47

### DIFF
--- a/forum/forum/settings.py
+++ b/forum/forum/settings.py
@@ -151,7 +151,7 @@ SIMPLE_JWT = {
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,
     'ALGORITHM': 'HS256',
-    'AUTH_HEADER_TYPES': ('Bearer'),
+    'AUTH_HEADER_TYPES': ('Bearer', ),
     'SIGNING_KEY': SECRET_KEY,
     'USER_ID_FIELD': 'user_id',
     'USER_ID_CLAIM': 'user_id',

--- a/forum/users/tests.py
+++ b/forum/users/tests.py
@@ -1,3 +1,29 @@
 from django.test import TestCase
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from rest_framework import status
+from users.models import User
 
-# Create your tests here.
+class UserRegistrationTest(APITestCase):
+    def setUp(self):
+        self.payload = {
+            "email": "test@example.com",
+            "password": "StrongPass123",
+            "user_name": "testuser1",
+            "first_name": "Tom",
+            "second_name": "Tester",
+            "role": 1,
+        }
+        self.url = reverse("register")
+    
+    def test_create_user_via_registration_endpoint(self):
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertTrue(User.objects.filter(email=self.payload["email"]).exists())
+        
+        user = User.objects.get(email=self.payload["email"])
+        self.assertEqual(user.user_name, self.payload["user_name"])
+        self.assertEqual(user.first_name, self.payload["first_name"])
+        self.assertTrue(user.check_password(self.payload["password"]))

--- a/forum/users/tests.py
+++ b/forum/users/tests.py
@@ -27,3 +27,14 @@ class UserRegistrationTest(APITestCase):
         self.assertEqual(user.user_name, self.payload["user_name"])
         self.assertEqual(user.first_name, self.payload["first_name"])
         self.assertTrue(user.check_password(self.payload["password"]))
+    
+    def test_register_existing_email_should_fail(self):
+        self.client.post(self.url, self.payload, format="json")
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_registration_without_password_should_fail(self):
+        data = self.payload.copy()
+        data.pop("password")
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
During previous tasks the registration logic was already implemented by my colleague @IrinaKrivoruchko, my actual task was to check if it works correctly and to close task on dashboard. I created test for registration and it ran successfully.

![image](https://github.com/user-attachments/assets/0ba5bc3f-aeef-40f0-a386-fb101422078b)


The actual registration (tested in Postman) also runs successfully

![image](https://github.com/user-attachments/assets/3e78ad86-5174-43a3-b640-eb13ba7aaa2b)

Files that can be checked for registration logic:
`users/serializers.py`
`users/test.py`
`users/urls.py`
`users/views.py`